### PR TITLE
Remove grep -P for Darwin compatibility

### DIFF
--- a/rules/dhall-freeze.sh
+++ b/rules/dhall-freeze.sh
@@ -36,7 +36,7 @@ unpack_tars() {
     [ $DEBUG -eq 1 ] && echo Unpacking $tar into $XDG_CACHE_HOME && tar -tvf $tar
     tar -xf $tar --strip-components=2 -C $XDG_CACHE_HOME/dhall .cache
     tar -xOf $tar source.dhall > $name
-    local hash=$(tar -xOf $tar binary.dhall | grep -Po '(?<=1220).*')
+    local hash=$(tar -xOf $tar binary.dhall | grep -o '1220\w*' | sed s/^1220//)
     export "DHALLBAZEL_$name=$PWD/$name"
     IMPORTHASH+=("$name")
     IMPORTHASH+=("$hash")


### PR DESCRIPTION
Tested on macOS 10.15.7, Ubuntu 18.04, and CentOS 7 for cross platform compatibility.