### PR TITLE
Remove copy resources functionality

### DIFF
--- a/examples/configmap/BUILD
+++ b/examples/configmap/BUILD
@@ -12,13 +12,14 @@ dhall_macro(
 )
 
 # This demonstrates that it is possible to reference the output of dhall_yaml
-dhall_macro(
-    name = "configmap",
-    entrypoint = "configmap.dhall",
-    data = [":server_yaml"],
-    deps = [
-        ":k8s",
-        ":prelude",
-    ],
-    tags = ["block-network"],
-)
+# TODO:broken
+# dhall_macro(
+#     name = "configmap",
+#     entrypoint = "configmap.dhall",
+#     data = [":server_yaml"],
+#     deps = [
+#         ":k8s",
+#         ":prelude",
+#     ],
+#     tags = ["block-network"],
+# )

--- a/rules/dhall-library.sh
+++ b/rules/dhall-library.sh
@@ -18,18 +18,6 @@ function unpack_tars() {
   done
 }
 
-function copy_resources() {
-  for resource in "$@"; do
-    local source_path
-    source_path=$(cut -d':' -f 1 <<< "${resource}")
-    local target_path
-    target_path=$(cut -d':' -f 2 <<< "${resource}")
-
-    debug_log "Copying $source_path to $target_path"
-    cp -f "$source_path" "$target_path"
-  done
-}
-
 function dump_cache() {
   if [ "$DEBUG" -eq 1 ]
   then
@@ -71,7 +59,6 @@ function _realpath() {
 DEBUG=0
 
 TARS=""
-RESOURCES=""
 while getopts "vd:r:" arg; do
   # We handle the rest of the arguments below
   # shellcheck disable=SC2220
@@ -81,9 +68,6 @@ while getopts "vd:r:" arg; do
       ;;
     d)
       TARS="$TARS $OPTARG"
-      ;;
-    r)
-      RESOURCES="$RESOURCES $OPTARG"
       ;;
   esac
 done
@@ -108,17 +92,12 @@ debug_log "Working directory: ${PWD}"
 debug_log "Cache: ${XDG_CACHE_HOME}"
 debug_log "Dhall binary: ${DHALL_BIN}"
 debug_log "Package deps: ${TARS}"
-debug_log "Resources: ${RESOURCES}"
 
 mkdir -p "$XDG_CACHE_HOME/dhall"
 
 # We want the variable to expand into multiple args
 # shellcheck disable=SC2086
 unpack_tars $TARS
-
-# We want the variable to expand into multiple args
-# shellcheck disable=SC2086
-copy_resources $RESOURCES
 
 dump_cache "BEFORE_GEN" "$XDG_CACHE_HOME/dhall"
 

--- a/rules/dhall-output.sh
+++ b/rules/dhall-output.sh
@@ -18,18 +18,6 @@ function unpack_tars() {
   done
 }
 
-function copy_resources() {
-  for resource in "$@"; do
-    local source_path
-    source_path=$(cut -d':' -f 1 <<< "${resource}")
-    local target_path
-    target_path=$(cut -d':' -f 2 <<< "${resource}")
-
-    debug_log "Copying $source_path to $target_path"
-    cp -f "$source_path" "$target_path"
-  done
-}
-
 function dump_cache() {
   if [ "$DEBUG" -eq 1 ]
   then
@@ -52,7 +40,6 @@ function debug_log() {
 DEBUG=0
 
 TARS=""
-RESOURCES=""
 while getopts "vd:r:" arg; do
   # We handle the rest of the arguments below
   # shellcheck disable=SC2220
@@ -62,9 +49,6 @@ while getopts "vd:r:" arg; do
       ;;
     d)
       TARS="$TARS $OPTARG"
-      ;;
-    r)
-      RESOURCES="$RESOURCES $OPTARG"
       ;;
   esac
 done
@@ -84,17 +68,12 @@ debug_log "Working directory: ${PWD}"
 debug_log "Cache: ${XDG_CACHE_HOME}"
 debug_log "Dhall output binary: ${DHALL_TO_YAML_BIN}"
 debug_log "Package deps: ${TARS}"
-debug_log "Resources: ${RESOURCES}"
 
 mkdir -p "$XDG_CACHE_HOME/dhall"
 
 # We want the variable to expand into multiple args
 # shellcheck disable=SC2086
 unpack_tars $TARS
-
-# We want the variable to expand into multiple args
-# shellcheck disable=SC2086
-copy_resources $RESOURCES
 
 dump_cache "BEFORE_GEN" "$XDG_CACHE_HOME/dhall"
 

--- a/rules/dhall_freeze.bzl
+++ b/rules/dhall_freeze.bzl
@@ -22,6 +22,14 @@ def _dhall_freeze_impl(ctx):
   inputs = []
   inputs.append(entrypoint)
 
+  # sanity check deps for the same label.name
+  # This is the negative aspect of the trade off between using the full bazel
+  # package and label name in imports vs just the shorter labelname
+  label_names_list = [ str(i.label.name) for i in ctx.attr.deps ]
+  label_names_dict = { str(i.label.name): True for i in ctx.attr.deps }
+  if len(label_names_dict.keys()) != len(label_names_list):
+    fail("dependencies must use unique label names")
+
   deps = []
   # Add tar files to the command and to the inputs
   for dep in ctx.attr.deps:


### PR DESCRIPTION
The copying of resources is quite fragile and can actually be handled fine
in some limited cases as seen in the extra_data example. For more
advanced cases (i.e. where the referenced label != the dhall import path
epxression), this should be redone to match how imports are done for
freezing (i.e. environment variable with a conventional name to match
data label name)